### PR TITLE
Removing space in description key.

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,4 +1,4 @@
 applications:
 - name: Dashboard
-  description : Simple demo app shows a dashboard.
+  description: Simple demo app shows a dashboard.
   mem: 96M


### PR DESCRIPTION
This should eliminate the Unknown key "description" error